### PR TITLE
Fix serialization bug in behavior layers.

### DIFF
--- a/src/psiz/keras/layers/behaviors/alcove_cell.py
+++ b/src/psiz/keras/layers/behaviors/alcove_cell.py
@@ -453,6 +453,7 @@ class ALCOVECell(tf.keras.layers.Layer):
                     self.lr_association_constraint
                 ),
                 "lr_association_trainable": self.lr_association_trainable,
+                "data_scope": self.data_scope,
             }
         )
         return config

--- a/src/psiz/keras/layers/behaviors/rank_similarity_base.py
+++ b/src/psiz/keras/layers/behaviors/rank_similarity_base.py
@@ -335,6 +335,7 @@ class RankSimilarityBase(tf.keras.layers.Layer):
                 "kernel_adapter": tf.keras.utils.serialize_keras_object(
                     self.kernel_adapter
                 ),
+                "data_scope": self.data_scope,
             }
         )
         return config

--- a/src/psiz/keras/layers/behaviors/rate_similarity_base.py
+++ b/src/psiz/keras/layers/behaviors/rate_similarity_base.py
@@ -252,6 +252,7 @@ class RateSimilarityBase(tf.keras.layers.Layer):
                 "rate_initializer": tf.keras.initializers.serialize(
                     self.rate_initializer
                 ),
+                "data_scope": self.data_scope,
             }
         )
         return config

--- a/tests/psiz/keras/layers/behaviors/test_alcove_cell.py
+++ b/tests/psiz/keras/layers/behaviors/test_alcove_cell.py
@@ -32,10 +32,36 @@ def test_serialization():
     embedding = tf.keras.layers.Embedding(
         11, 4, mask_zero=True, trainable=False,
     )
-    layer = ALCOVECell(units, similarity=similarity, percept=embedding)
-    config = layer.get_config()
 
-    recon_layer = ALCOVECell.from_config(config)
+    # Default options.
+    layer = ALCOVECell(units, similarity=similarity, percept=embedding, name="alcove_cell")
+    cfg = layer.get_config()
+    # Verify.
+    assert cfg["name"] == "alcove_cell"
+    assert cfg["trainable"] is True
+    assert cfg["dtype"] == "float32"
+    assert cfg["units"] == units
+    assert cfg["data_scope"] == "categorize"
+
+    recon_layer = ALCOVECell.from_config(cfg)
     tf.debugging.assert_equal(recon_layer.similarity.beta, 3.2)
     tf.debugging.assert_equal(recon_layer.similarity.tau, 1.0)
     assert recon_layer.units == units
+    assert recon_layer.data_scope == "categorize"
+
+    # Non-default options.
+    layer = ALCOVECell(units, similarity=similarity, percept=embedding, data_scope="abc")
+    cfg = layer.get_config()
+    # Verify.
+    # Verify.
+    assert cfg["name"] == "alcove_cell"
+    assert cfg["trainable"] is True
+    assert cfg["dtype"] == "float32"
+    assert cfg["units"] == units
+    assert cfg["data_scope"] == "abc"
+
+    recon_layer = ALCOVECell.from_config(cfg)
+    tf.debugging.assert_equal(recon_layer.similarity.beta, 3.2)
+    tf.debugging.assert_equal(recon_layer.similarity.tau, 1.0)
+    assert recon_layer.units == units
+    assert recon_layer.data_scope == "abc"

--- a/tests/psiz/keras/layers/behaviors/test_rank_similarity_cell.py
+++ b/tests/psiz/keras/layers/behaviors/test_rank_similarity_cell.py
@@ -161,3 +161,52 @@ def test_call_v1(ds_3rank1_v1):
     )
     outputs, states_t1 = rank_similarity_cell_call(ds_3rank1_v1, rank_cell)
     tf.debugging.assert_equal(tf.shape(outputs), tf.TensorShape([4, 1, 3]))
+
+
+def test_serialization():
+    """Test serialization."""
+    percept = percept_static_v0()
+    kernel = kernel_v0()
+
+    # Default settings.
+    rank_cell = psiz.keras.layers.RankSimilarityCell(
+        n_reference=2, n_select=1, percept=percept, kernel=kernel, name="rs1"
+    )
+    cfg = rank_cell.get_config()
+    # Verify.
+    assert cfg["name"] == "rs1"
+    assert cfg["trainable"] is True
+    assert cfg["dtype"] == "float32"
+    assert cfg["n_reference"] == 2
+    assert cfg["n_select"] == 1
+    assert cfg["data_scope"] == "given2rank1"
+
+    rank_cell2 = psiz.keras.layers.RankSimilarityCell.from_config(cfg)
+    assert rank_cell2.name == "rs1"
+    assert rank_cell2.trainable is True
+    assert rank_cell2.dtype == "float32"
+    assert rank_cell2.n_reference == 2
+    assert rank_cell2.n_select == 1
+    assert rank_cell2.data_scope == "given2rank1"
+
+    # All optional settings.
+    rank_cell = psiz.keras.layers.RankSimilarityCell(
+        n_reference=8, n_select=2, percept=percept, kernel=kernel, data_scope="abc",
+        name="rs2"
+    )
+    cfg = rank_cell.get_config()
+    # Verify.
+    assert cfg["name"] == "rs2"
+    assert cfg["trainable"] is True
+    assert cfg["dtype"] == "float32"
+    assert cfg["n_reference"] == 8
+    assert cfg["n_select"] == 2
+    assert cfg["data_scope"] == "abc"
+
+    rank_cell2 = psiz.keras.layers.RankSimilarity.from_config(cfg)
+    assert rank_cell2.name == "rs2"
+    assert rank_cell2.trainable is True
+    assert rank_cell2.dtype == "float32"
+    assert rank_cell2.n_reference == 8
+    assert rank_cell2.n_select == 2
+    assert rank_cell2.data_scope == "abc"

--- a/tests/psiz/keras/layers/behaviors/test_rate_similarity_cell.py
+++ b/tests/psiz/keras/layers/behaviors/test_rate_similarity_cell.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+# Copyright 2023 The PsiZ Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Module for testing models."""
+
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+import psiz
+
+
+def percept_static_v0():
+    """Static percept layer."""
+    n_stimuli = 20
+    n_dim = 3
+    percept = tf.keras.layers.Embedding(
+        n_stimuli + 1, n_dim, mask_zero=True
+    )
+    return percept
+
+
+def percept_stochastic_v0():
+    """Stochastic percept layer."""
+    n_stimuli = 20
+    n_dim = 3
+    prior_scale = .2
+    percept = psiz.keras.layers.EmbeddingNormalDiag(
+        n_stimuli + 1, n_dim, mask_zero=True,
+        scale_initializer=tf.keras.initializers.Constant(
+            tfp.math.softplus_inverse(prior_scale).numpy()
+        )
+    )
+    return percept
+
+
+def kernel_v0():
+    """A kernel layer."""
+    kernel = psiz.keras.layers.DistanceBased(
+        distance=psiz.keras.layers.Minkowski(
+            rho_initializer=tf.keras.initializers.Constant(2.),
+            w_initializer=tf.keras.initializers.Constant(1.),
+            trainable=False,
+        ),
+        similarity=psiz.keras.layers.ExponentialSimilarity(
+            beta_initializer=tf.keras.initializers.Constant(10.),
+            tau_initializer=tf.keras.initializers.Constant(1.),
+            gamma_initializer=tf.keras.initializers.Constant(0.001),
+            trainable=False,
+        )
+    )
+    return kernel
+
+
+# TODO add test calls analogous to `test_rank_similarity_cell.py`
+
+
+def test_serialization():
+    """Test serialization."""
+    percept = percept_static_v0()
+    kernel = kernel_v0()
+
+    # Default settings.
+    rate_cell = psiz.keras.layers.RateSimilarityCell(
+        percept=percept, kernel=kernel, name="rs1"
+    )
+    cfg = rate_cell.get_config()
+    # Verify.
+    assert cfg["name"] == "rs1"
+    assert cfg["trainable"] is True
+    assert cfg["dtype"] == "float32"
+    assert cfg["lower_trainable"] is False
+    assert cfg["upper_trainable"] is False
+    assert cfg["midpoint_trainable"] is True
+    assert cfg["rate_trainable"] is True
+    assert cfg["data_scope"] == "rate2"
+
+    rate_cell2 = psiz.keras.layers.RateSimilarityCell.from_config(cfg)
+    assert rate_cell2.name == "rs1"
+    assert rate_cell2.trainable is True
+    assert rate_cell2.dtype == "float32"
+    assert rate_cell2.lower_trainable is False
+    assert rate_cell2.upper_trainable is False
+    assert rate_cell2.midpoint_trainable is True
+    assert rate_cell2.rate_trainable is True
+    assert rate_cell2.data_scope == "rate2"
+
+    # All optional settings.
+    rate_cell = psiz.keras.layers.RateSimilarityCell(
+        percept=percept,
+        kernel=kernel,
+        data_scope="abc",
+        lower_trainable=True,
+        upper_trainable=True,
+        midpoint_trainable=False,
+        rate_trainable=False,
+        name="rs2",
+    )
+    cfg = rate_cell.get_config()
+    # Verify.
+    assert cfg["name"] == "rs2"
+    assert cfg["trainable"] is True
+    assert cfg["dtype"] == "float32"
+    assert cfg["lower_trainable"] is True
+    assert cfg["upper_trainable"] is True
+    assert cfg["midpoint_trainable"] is False
+    assert cfg["rate_trainable"] is False
+    assert cfg["data_scope"] == "abc"
+
+    rate_cell2 = psiz.keras.layers.RateSimilarityCell.from_config(cfg)
+    assert rate_cell2.name == "rs2"
+    assert rate_cell2.trainable is True
+    assert rate_cell2.dtype == "float32"
+    assert rate_cell2.lower_trainable is True
+    assert rate_cell2.upper_trainable is True
+    assert rate_cell2.midpoint_trainable is False
+    assert rate_cell2.rate_trainable is False
+    assert rate_cell2.data_scope == "abc"


### PR DESCRIPTION
- Add 'data_scope' attribute to serialization list. Re-instantiated objects will now have the correct data_scope prefix.